### PR TITLE
Fixed docker-compose and dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,5 +6,5 @@ RUN npm install -g yarn --force
 RUN yarn cache clean
 COPY src /opt/uci
 WORKDIR /opt/uci
-RUN yarn -i
-CMD ["node", "app.js", "&"]
+RUN yarn global add pm2
+CMD ["pm2-runtime", "app.js"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,5 +6,6 @@ RUN npm install -g yarn --force
 RUN yarn cache clean
 COPY src /opt/uci
 WORKDIR /opt/uci
+RUN yarn -i
 RUN yarn global add pm2
 CMD ["pm2-runtime", "app.js"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,9 @@ version: '3'
 
 services:
   federation-service:
-    build: .
+    build:
+      context: .
+      dockerfile: ./build/Dockerfile
     image: federation-service
     container_name: federation-service
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3"
 
 services:
   federation-service:
-    build: .
+    build:
+      context: .
+      dockerfile: ./build/Dockerfile
     image: uci-apis:0.0.1
     container_name: federation-service
     restart: unless-stopped


### PR DESCRIPTION
### Changes

The `docker-compose` is now pointing at the correct dockerfile. Also, the dockerfile is modified to install pm2 and use it instead of node. The pm2 installation instructions are added at the very end of the dockerfile in order to preserve caching of `node-modules`